### PR TITLE
Remove excessive `pwrstat -status` calls

### DIFF
--- a/upsmonitor
+++ b/upsmonitor
@@ -12,15 +12,18 @@ DBNAME=<InfluxDBName>
 
 while true; do
 
+# Collect the stats
+STATS=$(pwrstat -status)
+
 #Gather Values for statistics
-LOAD=$(pwrstat -status |grep Load | cat | awk '{print $2}')
-RUNTIME=$(pwrstat -status |grep Remaining | cat | awk '{print $3}')
-UTILVOLT=$(pwrstat -status |grep "Utility Voltage" | cat | awk '{print $3}')
-OUTVOLT=$(pwrstat -status |grep "Output Voltage" | cat | awk '{print $3}')
-BATTCAP=$(pwrstat -status |grep "Battery Capacity" | cat | awk '{print $3}')
-SUPPLY=$(pwrstat -status |grep "Power Supply" | cat | awk '{print $4}')
-STATE=$(pwrstat -status |grep "State" | cat | awk '{print $2}')
-RATING=$(pwrstat -status |grep "Rating Power" | cat | awk '{print $3}')
+LOAD=$(echo -e "$STATS" |grep Load | cat | awk '{print $2}')
+RUNTIME=$(echo -e "$STATS" |grep Remaining | cat | awk '{print $3}')
+UTILVOLT=$(echo -e "$STATS" |grep "Utility Voltage" | cat | awk '{print $3}')
+OUTVOLT=$(echo -e "$STATS" |grep "Output Voltage" | cat | awk '{print $3}')
+BATTCAP=$(echo -e "$STATS" |grep "Battery Capacity" | cat | awk '{print $3}')
+SUPPLY=$(echo -e "$STATS" |grep "Power Supply" | cat | awk '{print $4}')
+STATE=$(echo -e "$STATS" |grep "State" | cat | awk '{print $2}')
+RATING=$(echo -e "$STATS" |grep "Rating Power" | cat | awk '{print $3}')
 LOADPERCENT=$(echo "scale=2;($LOAD/$RATING)" | bc -l)
 
 #Check Power Supply, 1 = Utility Power, 0 = Battery Power


### PR DESCRIPTION
Cache the result of the first `pwrstat -status` call to be used to to pull all the stats from. 